### PR TITLE
Correctly handle different javascript realms/documents

### DIFF
--- a/src/blot/abstract/parent.ts
+++ b/src/blot/abstract/parent.ts
@@ -351,7 +351,7 @@ class ParentBlot extends ShadowBlot implements Parent {
         node.parentNode != null &&
         // @ts-expect-error Fix me later
         node.tagName !== 'IFRAME' &&
-        document.body.compareDocumentPosition(node) &
+        (node.ownerDocument ?? document).body.compareDocumentPosition(node) &
           Node.DOCUMENT_POSITION_CONTAINED_BY
       ) {
         return;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -83,7 +83,11 @@ export default class Registry implements RegistryInterface {
       } else if (query & Scope.LEVEL & Scope.INLINE) {
         match = this.types.inline;
       }
-    } else if (query instanceof Element) {
+    } else if (
+      query instanceof HTMLElement ||
+      query instanceof
+        (query.ownerDocument?.defaultView?.HTMLElement ?? HTMLElement)
+    ) {
       const names = (query.getAttribute('class') || '').split(/\s+/);
       names.some((name) => {
         match = this.classes[name];


### PR DESCRIPTION
In JavaScript, multiple different global contexts (realms) can exist with their own classes and document (https://tc39.es/ecma262/#realm) and they can access each others objects.

These realms are created by calls to `window.open` or when using `<iframe>`s. An application I am working on enables multi-monitor support by opening multiple browser windows that are all controlled from the primary tab. And Quill does not function correctly when initialized in one of these external windows.

This can lead to very unintuitive behavior, since using the global `document` can lead to incorrect results and `instanceof` unexpectedly returning `false`. And because of https://bugzilla.mozilla.org/show_bug.cgi?id=1470017 in FireFox, we cannot even control what realm our initial objects are part of.

Luckily, `nodes` own references to their `ownerDocument`, which has a reference to their `defaultView`, making it possible to write code that survives these conditions.

This PR removes the expectation that `document` is the only document that can exist and fixes an `instanceof Element`, that were hindering Quill from working correctly when initializing it in an iframe.

The [Quill PR](https://github.com/slab/quill/pull/4330) is prepared, but parchment needs to be updated for the E2E tests to pass in Firefox.