### PR TITLE
fix: the first-letter issue when using IME input

### DIFF
--- a/src/blot/abstract/parent.ts
+++ b/src/blot/abstract/parent.ts
@@ -219,8 +219,8 @@ class ParentBlot extends ShadowBlot implements Parent {
       refDomNode = refBlot.domNode;
     }
     if (
-      this.domNode.parentNode !== childBlot.domNode ||
-      this.domNode.nextSibling !== refDomNode
+      this.domNode !== childBlot.domNode.parentNode ||
+      childBlot.domNode.nextSibling !== refDomNode
     ) {
       this.domNode.insertBefore(childBlot.domNode, refDomNode);
     }


### PR DESCRIPTION

# The problem

This PR is trying to fix the issue of IME in quill editor: https://github.com/slab/quill/issues/4449

We found that if we want to fix the collaborative editing issue, we need to disable `batchStart` and `batchEnd` in the handlers.

https://github.com/slab/quill/blob/b213e1073bac1478649f26e3c0dad50ad0eb2a49/packages/quill/src/core/composition.ts#L42

Afterward, we found that the first letter from the IME input remains when typing on an empty line.

![2024-10-15 21 13 21](https://github.com/user-attachments/assets/bdc684c8-54ed-45c4-b7eb-6f711bb72786)

This PR fixes this issue.

# Root cause

We found that this is caused by Quill re-inserting the child element into the parent, even when the element is already in the correct position, which causes the browser to cancel the composition.

# The solution

Looking at the diff code, I’m not sure why it was written that way originally. However, it seems there is an issue with the logic, and I have made corrections here. After the correction, the above-mentioned issue is resolved
